### PR TITLE
Add support for torch DataLoader and custom torchvision image transforms

### DIFF
--- a/src/MajorTOMDataset.py
+++ b/src/MajorTOMDataset.py
@@ -45,7 +45,7 @@ class MajorTOM(Dataset):
         row = grid_cell.split('_')[0]
     
         path = self.local_dir / Path("{}/{}/{}".format(row, grid_cell, product_id))
-        out_dict = {'meta' : self._metadata_to_torch(meta)}
+        out_dict = {'meta' : meta}
         
         for band in self.tif_bands:
             with rio.open(path / '{}.tif'.format(band)) as f:
@@ -62,10 +62,3 @@ class MajorTOM(Dataset):
             out_dict[band] = out
 
         return out_dict
-
-    def _metadata_to_torch(self, meta):
-        meta = meta.to_dict() # to dict
-        meta['timestamp'] = meta['timestamp'].timestamp() # convert to float
-        del meta['geometry'] # remove geometry
-        meta = {k: torch.tensor(v) if not isinstance(v,str) else v for k,v in meta.items()} # convert to torch tensor all non-string values
-        return meta

--- a/src/MajorTOMDataset.py
+++ b/src/MajorTOMDataset.py
@@ -55,7 +55,7 @@ class MajorTOM(Dataset):
 
         for band in self.png_bands:
             out = Image.open(path / '{}.png'.format(band))
-            if self.transforms is not None:
+            if self.custom_transforms is not None:
                 out = self.custom_transforms(out)
             out_dict[band] = out
 

--- a/src/MajorTOMDataset.py
+++ b/src/MajorTOMDataset.py
@@ -23,14 +23,14 @@ class MajorTOM(Dataset):
                  local_dir = None,
                  tif_bands=['B04','B03','B02'],
                  png_bands=['thumbnail'],
-                 transforms=[transforms.ToTensor()]
+                 custom_transforms=[transforms.ToTensor()]
                 ):
         super().__init__()
         self.df = df
         self.local_dir = Path(local_dir) if isinstance(local_dir,str) else local_dir
         self.tif_bands = tif_bands if not isinstance(tif_bands,str) else [tif_bands]
         self.png_bands = png_bands if not isinstance(png_bands,str) else [png_bands]
-        self.transforms = transforms
+        self.custom_transforms = transforms.Compose(custom_transforms) if custom_transforms is not None else None
 
     def __len__(self):
         return len(self.df)
@@ -48,15 +48,15 @@ class MajorTOM(Dataset):
         for band in self.tif_bands:
             with rio.open(path / '{}.tif'.format(band)) as f:
                 out = f.read()
-            if self.transforms is not None:
-                out = self.transforms(out)
+            if self.custom_transforms is not None:
+                out = self.custom_transforms(out)
             out_dict[band] = out
 
 
         for band in self.png_bands:
             out = Image.open(path / '{}.png'.format(band))
             if self.transforms is not None:
-                out = self.transforms(out)
+                out = self.custom_transforms(out)
             out_dict[band] = out
 
         return out_dict

--- a/src/MajorTOMDataset.py
+++ b/src/MajorTOMDataset.py
@@ -23,14 +23,16 @@ class MajorTOM(Dataset):
                  local_dir = None,
                  tif_bands=['B04','B03','B02'],
                  png_bands=['thumbnail'],
-                 custom_transforms=[transforms.ToTensor()]
+                 tif_transforms=[transforms.ToTensor()],
+                 png_transforms=[transforms.ToTensor()]
                 ):
         super().__init__()
         self.df = df
         self.local_dir = Path(local_dir) if isinstance(local_dir,str) else local_dir
         self.tif_bands = tif_bands if not isinstance(tif_bands,str) else [tif_bands]
         self.png_bands = png_bands if not isinstance(png_bands,str) else [png_bands]
-        self.custom_transforms = transforms.Compose(custom_transforms) if custom_transforms is not None else None
+        self.tif_transforms = transforms.Compose(tif_transforms) if tif_transforms is not None else None
+        self.png_transforms = transforms.Compose(png_transforms) if png_transforms is not None else None
 
     def __len__(self):
         return len(self.df)
@@ -48,15 +50,15 @@ class MajorTOM(Dataset):
         for band in self.tif_bands:
             with rio.open(path / '{}.tif'.format(band)) as f:
                 out = f.read()
-            if self.custom_transforms is not None:
-                out = self.custom_transforms(out)
+            if self.tif_transforms is not None:
+                out = self.tif_transforms(out)
             out_dict[band] = out
 
 
         for band in self.png_bands:
             out = Image.open(path / '{}.png'.format(band))
-            if self.custom_transforms is not None:
-                out = self.custom_transforms(out)
+            if self.png_transforms is not None:
+                out = self.png_transforms(out)
             out_dict[band] = out
 
         return out_dict


### PR DESCRIPTION
Hi.
Thanks for the great work.
I think it would be very handy to support `torch.dataloader` in `MajorTOM` class, such that it can be loaded like below.
```python
train_dataset = MajorTOM(df=filtered_df, local_dir='path/datasets/majorTOM/euro/L2A',
                                              tif_bands=[], png_bands=['thumbnail'])

train_dataset_loader = DataLoader(
    train_dataset,
    batch_size=32,
    shuffle=False,
    drop_last=False,
    num_workers=8,
    pin_memory=True,
    persistent_workers=True,
)
```
In the current version, trying to directly use `torch.utils.data.Dataloader` will yield errors, as variable `meta` in `__getitem__` is not tensor-friendly, nor the images from the bands.

## Metadata
I added a small helper function to convert attributes to tensors. Note, however, that there are some design decisions to consider (e.g. removing point geometry, datetime to float timestamp).

This is the naive implementation but feel free to edit as much as you want.

## Images
It would be nice to allow `torchvision.transforms`. I have added very simple code that allows adding custom transforms to `MajorTOM`, for tifs and pngs respectively. By default, ToTensor().

Again, feel free to do any edits/comments on this.