### PR TITLE
Fix missing dependencies in setup.py and resolve indentation error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup(
     install_requires=[
       "torch>=1.10.0",
       "torchvision",
+      "torchgeo", # Added New
+      "open_clip_torch", # Added New
       "pandas",
       "geopandas",
       "numpy",

--- a/src/embedder/models/SSL4EO_S2L1C.py
+++ b/src/embedder/models/SSL4EO_S2L1C.py
@@ -80,7 +80,7 @@ class SSL4EO_S2L1C_Embedder(torch.nn.Module):
         Returns:
             torch.Tensor: Preprocessed input, scaled by a factor of 10,000.
         """
-       return input / 1e4
+        return input / 1e4
 
     def forward(self, input):
         """


### PR DESCRIPTION
- Added missing dependencies `torchgeo` and `open_clip_torch` to `setup.py`, which caused import errors.
- Fixed an `IndentationError` in `Major-TOM\src\embedder\models\SSL4EO_S2L1C.py` caused by one less space.
